### PR TITLE
Add ability to handle dismissed PR reviews

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const APPROVE = 'APPROVE';
 const MANUAL_MERGE_MESSAGE = 'merge this manually';
 const RENOVATE_BOT = 'renovate[bot]';
 const RENOVATE_APPROVE_BOT = 'renovate-approve[bot]';
-ds
+
 module.exports = robot => {
   robot.log('App is loaded');
   robot.on('pull_request.opened', async context => {

--- a/index.js
+++ b/index.js
@@ -1,32 +1,37 @@
-const APPROVE = 'APPROVE';
-const MANUAL_MERGE_MESSAGE = 'merge this manually';
-const RENOVATE_BOT = 'renovate[bot]';
-const RENOVATE_APPROVE_BOT = 'renovate-approve[bot]';
+const APPROVE = "APPROVE";
+const MANUAL_MERGE_MESSAGE = "merge this manually";
+const RENOVATE_BOT = "renovate[bot]";
+const RENOVATE_APPROVE_BOT = "renovate-approve[bot]";
 
-module.exports = robot => {
-  robot.log('App is loaded');
-  robot.on('pull_request.opened', async context => {
+module.exports = app => {
+  app.log("App is loaded");
+  app.on("pull_request.opened", async context => {
+    app.log("Received PR open event");
     if (
       context.payload.sender.login === RENOVATE_BOT &&
       !context.payload.body.pull_request.body.includes(MANUAL_MERGE_MESSAGE)
     ) {
+      app.log("Approving new PR");
       const params = context.repo();
       params.number = context.payload.number;
       params.event = APPROVE;
       return context.github.pullRequests.createReview(params);
     }
   });
-  robot.on('pull_request_review.dismissed', async context => {
+  app.on("pull_request_review.dismissed", async context => {
+    app.log("Received PR review dismiss event");
+    app.log(context.payload);
     if (
-        context.payload.sender.login === RENOVATE_BOT &&
-        !context.payload.body.pull_request.body.includes(MANUAL_MERGE_MESSAGE) &&
-        context.payload.review.user.login === RENOVATE_APPROVE_BOT &&
-        context.payload.pull_request.user.login === RENOVATE_BOT
-      ) {
-        const params = context.repo();
-        params.number = context.payload.number;
-        params.event = APPROVE;
-        return context.github.pullRequests.createReview(params);
-      }
+      context.payload.sender.login === RENOVATE_BOT &&
+      !context.payload.body.pull_request.body.includes(MANUAL_MERGE_MESSAGE) &&
+      context.payload.review.user.login === RENOVATE_APPROVE_BOT &&
+      context.payload.pull_request.user.login === RENOVATE_BOT
+    ) {
+      app.log("Re-approving dismissed approval");
+      const params = context.repo();
+      params.number = context.payload.number;
+      params.event = APPROVE;
+      return context.github.pullRequests.createReview(params);
+    }
   });
 };

--- a/index.js
+++ b/index.js
@@ -1,14 +1,32 @@
+const APPROVE = 'APPROVE';
+const MANUAL_MERGE_MESSAGE = 'merge this manually';
+const RENOVATE_BOT = 'renovate[bot]';
+const RENOVATE_APPROVE_BOT = 'renovate-approve[bot]';
+ds
 module.exports = robot => {
   robot.log('App is loaded');
   robot.on('pull_request.opened', async context => {
     if (
-      context.payload.sender.login === 'renovate[bot]' &&
-      !context.payload.body.pull_request.body.includes('merge this manually')
+      context.payload.sender.login === RENOVATE_BOT &&
+      !context.payload.body.pull_request.body.includes(MANUAL_MERGE_MESSAGE)
     ) {
       const params = context.repo();
       params.number = context.payload.number;
-      params.event = 'APPROVE';
+      params.event = APPROVE;
       return context.github.pullRequests.createReview(params);
     }
+  });
+  app.on('pull_request_review.dismissed', async context => {
+    if (
+        context.payload.sender.login === RENOVATE_BOT &&
+        !context.payload.body.pull_request.body.includes(MANUAL_MERGE_MESSAGE) &&
+        context.payload.review.user.login === RENOVATE_APPROVE_BOT &&
+        context.payload.pull_request.user.login === RENOVATE_BOT
+      ) {
+        const params = context.repo();
+        params.number = context.payload.number;
+        params.event = APPROVE;
+        return context.github.pullRequests.createReview(params);
+      }
   });
 };

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = robot => {
       return context.github.pullRequests.createReview(params);
     }
   });
-  app.on('pull_request_review.dismissed', async context => {
+  robot.on('pull_request_review.dismissed', async context => {
     if (
         context.payload.sender.login === RENOVATE_BOT &&
         !context.payload.body.pull_request.body.includes(MANUAL_MERGE_MESSAGE) &&


### PR DESCRIPTION
Addresses #10 

This change will allow a re-approval of a pull request that rebased by `renovate[bot]`.

Re-approval requires the following conditions to be met:
- The original pull request was opened by `renovate[bot]`
- The approval being dismissed was created by `renovate-approve[bot]`
- The dismissing commit was created by `renovate[bot]`
- The pull request body does not contain the string `merge this manually` which indicates the PR can be merged automatically.

I have been unable to validate this myself. It will need to be tested before being released. I have a high level of confidence that it will work as anticipated, but you can never be 100%!