### PR TITLE
feat: enable enterprise support by allowing overrides

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const APPROVE = "APPROVE";
 const MANUAL_MERGE_MESSAGE = "merge this manually";
-const RENOVATE_BOT = "renovate[bot]";
-const RENOVATE_APPROVE_BOT = "renovate-approve[bot]";
+const RENOVATE_BOT = process.env.RENOVATE_BOT_USER || "renovate[bot]";
+const RENOVATE_APPROVE_BOT = process.env.RENOVATE_APPROVE_BOT_USER || "renovate-approve[bot]";
 
 function isRenovateApproved(context) {
   return context && context.payload && context.payload.review;


### PR DESCRIPTION
This allows one to override the renovate bot check values.
This enables enterprise deployments who may have different names.

(note i removed the version updates from this PR)