### PR TITLE
chore(engine): require node 12 (current lts) via engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "probot": "7.5.3"
   },
   "engines": {
-    "node": "8.x"
+    "node": "12.x"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: since folks may consume this repo via npm or directly
via composite probot apps, this is a breaking change due to requiring
a new node.js version major.

Though I would perhaps worry about this only after https://github.com/renovatebot/renovate-approve-bot/pull/15