### PR TITLE
fix: switch to context.github.pulls

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = app => {
   function approvePr(context) {
     try {
       const params = context.issue({ event: APPROVE });
-      return context.github.pullRequests.createReview(params);
+      return context.github.pulls.createReview(params);
     } catch (err) {
       app.log(err);
       app.log(context.payload);


### PR DESCRIPTION
context.github.pullRequests keep giving me this error. This is why I switch it to use `pulls` and things seem to work well now
```
21:48:37.047Z  INFO probot: Cannot read property 'createReview' of undefined
  TypeError: Cannot read property 'createReview' of undefined
      at approvePr (/opt/app/index.js:47:42)
      at /opt/app/index.js:57:14
      at Application.<anonymous> (/opt/app/node_modules/probot/lib/application.js:154:50)
      at step (/opt/app/node_modules/probot/lib/application.js:44:23)
      at Object.next (/opt/app/node_modules/probot/lib/application.js:25:53)
      at fulfilled (/opt/app/node_modules/probot/lib/application.js:16:58)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
```