### PR TITLE
build: engines node 14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "probot": "9.15.1"
   },
   "engines": {
-    "node": "12.x"
+    "node": "14.x"
   }
 }


### PR DESCRIPTION
## Changes:

- Bump `engines node:` from `12.x` to `14.x`

## Context:

@rarkins bumped the Docker image to Node 14 with commit 1354c87, so maybe we want to bump the supported version of Node in the `package.json` file as well?