### PR TITLE
fix(Dockerfile): use alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/node:14.15.5
+FROM amd64/node:14.15.5-alpine
 
 LABEL maintainer="Rhys Arkins <rhys@arkins.net>"
 


### PR DESCRIPTION
It appears the changing the base image resulted in a small build issue. Requesting the `alpine` variant resolved the issue. The fix is included in this PR.

To reproduce the build issue, run `docker build .`. The output and error is included below:

``` bash
$ docker build .
Sending build context to Docker daemon  349.7kB
Step 1/13 : FROM amd64/node:14.15.5
 ---> 060aed823995
Step 2/13 : LABEL maintainer="Rhys Arkins <rhys@arkins.net>"
 ---> Using cache
 ---> 1b5ae0179bcf
Step 3/13 : WORKDIR /opt/app/
 ---> Using cache
 ---> 5dfe3d3e4b47
Step 4/13 : ARG USER_UID=1001
 ---> Using cache
 ---> f82635501f0a
Step 5/13 : ARG USER_GID=1001
 ---> Using cache
 ---> f1c85fff4f63
Step 6/13 : ARG APP_DIR=/opt/app/
 ---> Using cache
 ---> ed3a072d17b6
Step 7/13 : RUN addgroup -g ${USER_GID} renovate     && adduser -u ${USER_UID} -G renovate -s /bin/sh -D renovate     && mkdir -p ${APP_DIR}     && chown -R ${USER_UID}:${USER_GID} ${APP_DIR}     && apk add --no-cache python     && apk add --no-cache make
 ---> Running in f521052e8ff1
Option g is ambiguous (gecos, gid, group)
adduser [--home DIR] [--shell SHELL] [--no-create-home] [--uid ID]
[--firstuid ID] [--lastuid ID] [--gecos GECOS] [--ingroup GROUP | --gid ID]
[--disabled-password] [--disabled-login] [--add_extra_groups] USER
   Add a normal user

adduser --system [--home DIR] [--shell SHELL] [--no-create-home] [--uid ID]
[--gecos GECOS] [--group | --ingroup GROUP | --gid ID] [--disabled-password]
[--disabled-login] [--add_extra_groups] USER
   Add a system user

adduser --group [--gid ID] GROUP
addgroup [--gid ID] GROUP
   Add a user group

addgroup --system [--gid ID] GROUP
   Add a system group

adduser USER GROUP
   Add an existing user to an existing group

general options:
  --quiet | -q      don't give process information to stdout
  --force-badname   allow usernames which do not match the
                    NAME_REGEX configuration variable
  --help | -h       usage message
  --version | -v    version number and copyright
  --conf | -c FILE  use FILE as configuration file

The command '/bin/sh -c addgroup -g ${USER_GID} renovate     && adduser -u ${USER_UID} -G renovate -s /bin/sh -D renovate     && mkdir -p ${APP_DIR}     && chown -R ${USER_UID}:${USER_GID} ${APP_DIR}     && apk add --no-cache python     && apk add --no-cache make' returned a non-zero code: 1
```