### PR TITLE
Add link to GitHub Apps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # renovate-approve-bot
 
 A GitHub App that serves only to submit approving Pull Request Reviews for PRs from [Renovate Bot](https://github.com/apps/renovate). This enables you to require Pull Request Reviews on your project while also still utilising Renovate's "automerge" benefits.
+
+Install it here: https://github.com/apps/renovate-approve

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 A GitHub App that serves only to submit approving Pull Request Reviews for PRs from [Renovate Bot](https://github.com/apps/renovate). This enables you to require Pull Request Reviews on your project while also still utilising Renovate's "automerge" benefits.
 
-Install it here: https://github.com/apps/renovate-approve
+If you are using the Mend Renovate App for github.com then you can install a hosted version of this approve bot here: https://github.com/apps/renovate-approve


### PR DESCRIPTION
Landed on this repo and had to Google the name to find the install link. Having the link in the README (and/or maybe in the GitHub repo "description" section?) might be useful for folks.